### PR TITLE
feat: add prefixes for chainid

### DIFF
--- a/packages/eth/src/token.ts
+++ b/packages/eth/src/token.ts
@@ -1,5 +1,5 @@
 import type { Signer } from "ethers";
-import { utils } from "ethers";
+import { utils, BigNumber } from "ethers";
 import {
   createAndSignToken,
   Header,
@@ -12,7 +12,9 @@ export async function create(
 ): Promise<string> {
   // WARN: This is a non-standard JWT
   // Borrows ideas from: https://github.com/ethereum/EIPs/issues/1341
-  const kid = await signer.getAddress();
+  const address = await signer.getAddress();
+  const chainId = await signer.getChainId();
+  const kid = `eth:${chainId}:${address}`;
   const header: Header = { alg: "ETH", typ: "JWT", kid };
   const sign = {
     signMessage: async (message: Uint8Array): Promise<Uint8Array> => {

--- a/packages/eth/src/token.ts
+++ b/packages/eth/src/token.ts
@@ -13,7 +13,7 @@ export async function create(
   // WARN: This is a non-standard JWT
   // Borrows ideas from: https://github.com/ethereum/EIPs/issues/1341
   const address = await signer.getAddress();
-  const chainId = await signer.getChainId();
+  const chainId = signer.provider ? await signer.getChainId() : "unknown";
   const kid = `eth:${chainId}:${address}`;
   const header: Header = { alg: "ETH", typ: "JWT", kid };
   const sign = {

--- a/packages/eth/tests/token.test.ts
+++ b/packages/eth/tests/token.test.ts
@@ -1,12 +1,14 @@
 import { expect } from "chai";
-import { Wallet, utils } from "ethers";
+import { utils } from "ethers";
 import { decodeURLSafe } from "@stablelib/base64";
+import { MockProvider } from "ethereum-waffle";
 import { create } from "../src/token";
+
+const eth = new MockProvider();
+const [signer] = eth.getWallets();
 
 const decoder = new TextDecoder();
 const decode = decoder.decode.bind(decoder);
-
-const signer = Wallet.createRandom();
 
 const aud = "broker.id";
 
@@ -19,7 +21,8 @@ describe("eth/token", () => {
 
   test("jws has correct header", async () => {
     const token = await create(signer, { aud });
-    const kid = await signer.getAddress();
+    const addr = await signer.getAddress();
+    const kid = `eth:1337:${addr}`;
     const [h] = token.split(".");
     const header = JSON.parse(decode(decodeURLSafe(h)));
     expect(header).to.have.property("alg", "ETH");
@@ -28,7 +31,8 @@ describe("eth/token", () => {
   });
 
   test("jws has correct payload", async () => {
-    const kid = await signer.getAddress();
+    const addr = await signer.getAddress();
+    const kid = `eth:1337:${addr}`;
     const token = await create(signer, { aud });
     const [, p] = token.split(".");
     const payload = JSON.parse(decode(decodeURLSafe(p)));

--- a/packages/near/src/token.ts
+++ b/packages/near/src/token.ts
@@ -15,7 +15,8 @@ export function encodeKey(publicKey: Uint8Array): string {
   buffer[1] = 0x01;
   buffer.set(publicKey, 2);
   // prefix with `z` to indicate multi-base base58btc encoding
-  const kid = `z${base58btc(buffer)}`;
+  const key = `z${base58btc(buffer)}`;
+  const kid = `${"near:testnet"}:${key}`;
   return kid;
 }
 


### PR DESCRIPTION
As per our prior discussion. This now means that JWTs look something like this:

## Header
```json
{
  "alg": "ETH",
  "typ": "JWT",
  "kid": "eth:rinkeby:0x0000000..."
};
```

## Payload
```json
{
  "nbf": 12345,
  "iat": 12345,
  "exp": 56789,
  "iss": "eth:rinkeby:0x0000000...",
  "sub": "eth:rinkeby:0x0000000...",
  "aud": "0x111111111..."
}
```

I've used `:` as delimiters because these cannot show up in the address itself, so it is a safe delimiter to use. Additionally, it is similar to the did spec, though I've moved away from using "proper" key dids here because that adds complexity that we just don't need.

Note that aud is the address of the provider, and kid is the key id for the address. This is a non-standard JWT, with borrows ideas from https://github.com/ethereum/EIPs/issues/1341. This can be validated for polygon and ethereum by extracting the address from the header, and using https://goethereumbook.org/signature-verify/ to verify that the signed payload was signed by the correct private key/address.