### PR TITLE
test(exports): rm status from top level exports

### DIFF
--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -12,7 +12,7 @@ import { isReadableStream } from "./utils";
  * * `Success` indicates that the request was stored in Filecoin.
  * * `Error indicates that there is some error handling the request.
  */
-export type Status =
+type Status =
   | "Unknown"
   | "Batching"
   | "Preparing"

--- a/packages/eth/src/index.ts
+++ b/packages/eth/src/index.ts
@@ -14,7 +14,6 @@ export { createToken };
 export {
   CoreAPI,
   StandardClaims,
-  Status,
   Request,
   RequestInfo,
   Deal,

--- a/packages/near/src/index.ts
+++ b/packages/near/src/index.ts
@@ -14,7 +14,6 @@ export { createToken };
 export {
   CoreAPI,
   StandardClaims,
-  Status,
   Request,
   RequestInfo,
   Deal,


### PR DESCRIPTION
## Summary

Attempting to isolate an error happening with version 0.0.7 released.

```
Failed to compile.

./node_modules/@textile/eth-storage/dist/esm/index.js
Attempted import error: 'Status' is not exported from '@textile/core-storage'.
```

You can see the failure here https://github.com/textileio/storage-js-basic-demo/actions/runs/1118230723

It appears to come from this commit:

https://github.com/textileio/storage-js/commit/0d5a877685109386f75d9fd76121b56b3a8e73d7
